### PR TITLE
#220 emailbounceのユーザーにメールを送ると、直後にエラーのメッセージが出る。

### DIFF
--- a/qa-email-bounce-overrides.php
+++ b/qa-email-bounce-overrides.php
@@ -8,7 +8,7 @@ function qa_send_email($params, $async=false, $buffering=false, $eventid=null, $
 {
 	if(email_bounce_db::is_emailbounced($params['toemail'])) {
 		error_log('qa_send_email: in emailbounce:' . $params['toemail']);
-		return;
+		return true;
 	}
 
 	return qa_send_email_base($params, $async, $buffering, $eventid, $userid);


### PR DESCRIPTION
- emailbounce に登録されている場合は true を返す（実際は送信しない）
