### PR TITLE
1430 メールが一度未達になると、その後メールアドレスを変更しても、bounceフラグが変わらない

### DIFF
--- a/email-bounce-db.php
+++ b/email-bounce-db.php
@@ -47,6 +47,16 @@ class email_bounce_db
 		return qa_db_read_one_value(qa_db_query_sub($sql, $email),true);
 	}
 
+	public static function get_email_from_userid($userid = null)
+	{
+		if (!isset($userid)) {
+			return array();
+		}
+
+		$sql = 'SELECT email FROM ^emailbounce WHERE userid = $';
+		return qa_db_read_all_values(qa_db_query_sub($sql, $userid),true);
+	}
+
 	public static function create_or_update_emailbounce($userid, $email)
 	{
 		if (empty($email)) {
@@ -94,6 +104,7 @@ class email_bounce_db
 			);
 		}
 	}
+
 	public static function is_emailbounced($email, $userid = null)
 	{
 		if (empty($email)) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,12 @@
+{
+	"name": "Email Bounce",
+	"uri": "https://github.com/yshiga/q2a-email-bounce",
+	"description": "Notify the user of an unachievable mail.",
+	"version": "1.0.0",
+	"date": "2016-08-17",
+	"author": "38qa.net",
+	"author_uri": "http://38qa.net",
+	"license": "GPLv2",
+	"update_uri": "",
+	"min_q2a": "1.7"
+}

--- a/qa-email-bounce-event.php
+++ b/qa-email-bounce-event.php
@@ -9,9 +9,13 @@ class q2a_email_bounce_event {
     function process_event($event, $post_userid, $post_handle, $cookieid, $params)
     {
         if ($event === 'u_save') {
-            error_log('u_save: user_id: '.$post_userid);
-            $email=qa_get_user_email($post_userid);
-            error_log('u_save: email: '.$email);
+            $cur_email=qa_get_user_email($post_userid);
+            $bouncemail = email_bounce_db::get_email_from_userid($post_userid);
+            foreach ($bouncemail as $email) {
+                if ($cur_email !== $email) {
+                    email_bounce_db::update_emailbounce($post_userid, $email, 0);
+                }
+            }
         }
     }
 }

--- a/qa-email-bounce-event.php
+++ b/qa-email-bounce-event.php
@@ -1,0 +1,17 @@
+<?php
+// don't allow this page to be requested directly from browser
+if (!defined('QA_VERSION')) {
+	header('Location: ../../');
+	exit;
+}
+
+class q2a_email_bounce_event {
+    function process_event($event, $post_userid, $post_handle, $cookieid, $params)
+    {
+        if ($event === 'u_save') {
+            error_log('u_save: user_id: '.$post_userid);
+            $email=qa_get_user_email($post_userid);
+            error_log('u_save: email: '.$email);
+        }
+    }
+}

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -33,6 +33,7 @@ qa_register_plugin_overrides('qa-email-bounce-overrides.php');
 // qa_register_plugin_layer('qa-email-bounce-layer.php','Email Bounce Layer');
 // widgets
 qa_register_plugin_module('widget','qa-email-bounce-widget.php','qa_email_bounce_widget','Email Bounce Notification');
+qa_register_plugin_module('event', 'qa-email-bounce-event.php', 'q2a_email_bounce_event', 'Email Bounce');
 
 /*
 	Omit PHP closing tag to help avoid accidental output


### PR DESCRIPTION
- ユーザー情報保存時、メールアドレスが`emailbounce`のものと変わっていたらフラグを`0`にする